### PR TITLE
Remove variable from the Frogbot workflows

### DIFF
--- a/.github/workflows/frogbot-scan-and-fix.yml
+++ b/.github/workflows/frogbot-scan-and-fix.yml
@@ -34,7 +34,3 @@ jobs:
           # [Mandatory]
           # The GitHub token automatically generated for the job
           JF_GIT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-          # [Mandatory if the `installCommand` variable isn't set in your frogbot-config.yml file]
-          # The command that installs the project dependencies (e.g "npm i")
-          JF_INSTALL_DEPS_CMD: "npm i"

--- a/.github/workflows/frogbot-scan-pull-request.yml
+++ b/.github/workflows/frogbot-scan-pull-request.yml
@@ -35,7 +35,3 @@ jobs:
           # [Mandatory]
           # The GitHub token automatically generated for the job
           JF_GIT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-          # [Mandatory if the `installCommand` variable isn't set in your frogbot-config.yml file]
-          # The command that installs the project dependencies (e.g "npm i")
-          JF_INSTALL_DEPS_CMD: "npm i"


### PR DESCRIPTION
Removed the JF_INSTALL_DEPS_CMD variable from the Frogbot workflows, since Frogbot no longer requires it for npm.