### PR TITLE
Fix summary always shown

### DIFF
--- a/src/components/Page/Eos/Eos.tsx
+++ b/src/components/Page/Eos/Eos.tsx
@@ -22,7 +22,7 @@ export default function Eos(props: Props): JSX.Element {
 				text={props.data.header}
 				isResearch={false}
 			/>
-			<Summary expandButton={false}>
+			<Summary showAll expandButton={false}>
 				<Vulnerability location={`${props.data.location.file}`} />
 				<Severity severity={props.data.severity ? props.data.severity : ISeverity.Unknown} />
 				<VulnerabilityLine line={`${props.data.location.startRow}`} />

--- a/src/components/Page/Eos/Eos.tsx
+++ b/src/components/Page/Eos/Eos.tsx
@@ -24,9 +24,9 @@ export default function Eos(props: Props): JSX.Element {
 			/>
 			<Summary showAll expandButton={false}>
 				<Vulnerability location={`${props.data.location.file}`} />
-				<Severity severity={props.data.severity ? props.data.severity : ISeverity.Unknown} />
 				<VulnerabilityLine line={`${props.data.location.startRow}`} />
 				{!!props.data.ruleId && <Row title="Rule ID" data={props.data.ruleId} />}
+				<Severity severity={props.data.severity ? props.data.severity : ISeverity.Unknown} />
 			</Summary>
 			<Research description={props.data.description} remediation={props.data.remediation} />
 			<ContextualAnalysis

--- a/src/components/UI/Summary/Summary.module.css
+++ b/src/components/UI/Summary/Summary.module.css
@@ -8,6 +8,7 @@
 }
 
 .halfText {
+	max-height: 5em;
 	line-height: 22px;
 	overflow: hidden;
 	transition: max-height 1s ease-out;


### PR DESCRIPTION
Fixed a bug that caused the issue summary always be fully shown, even if it should be collapsed.