### PR TITLE
Update login popup window

### DIFF
--- a/src/components/UI/Modal/pages/LoginModal.test.tsx
+++ b/src/components/UI/Modal/pages/LoginModal.test.tsx
@@ -27,7 +27,7 @@ describe('LoginModal component', () => {
 
 	describe('JFrog CLI', () => {
 		const mockLoginData: ILoginPage = {
-			status: LoginProgressStatus.Verifying,
+			status: LoginProgressStatus.AutoConnect,
 			connectionType: LoginConnectionType.Cli,
 			url: 'example.com',
 			pageType: PageType.Login
@@ -40,11 +40,10 @@ describe('LoginModal component', () => {
 					getByText('It looks like JFrog CLI is installed with the connection details of')
 				).toBeInTheDocument()
 				expect(getByText('example.com')).toBeInTheDocument()
-				expect(getByText('Verifying...')).toBeInTheDocument()
 				expect(document.querySelector('.closeBtn')).toBeInTheDocument()
 				expect(document.querySelector('.text')).toBeInTheDocument()
 				expect(document.querySelector('.welcome')).toBeInTheDocument()
-				expect(document.querySelector('.autoConnectBtn')).not.toBeInTheDocument()
+				expect(document.querySelector('.autoConnectBtn')).toBeInTheDocument()
 			})
 		})
 
@@ -92,7 +91,7 @@ describe('LoginModal component', () => {
 	})
 	describe('Env Vars', () => {
 		const mockLoginData: ILoginPage = {
-			status: LoginProgressStatus.Verifying,
+			status: LoginProgressStatus.AutoConnect,
 			connectionType: LoginConnectionType.EnvVars,
 			url: 'example.com',
 			pageType: PageType.Login
@@ -105,11 +104,10 @@ describe('LoginModal component', () => {
 					getByText('Environment variables are set with the connection details of')
 				).toBeInTheDocument()
 				expect(getByText('example.com')).toBeInTheDocument()
-				expect(getByText('Verifying...')).toBeInTheDocument()
 				expect(document.querySelector('.closeBtn')).toBeInTheDocument()
 				expect(document.querySelector('.text')).toBeInTheDocument()
 				expect(document.querySelector('.welcome')).toBeInTheDocument()
-				expect(document.querySelector('.autoConnectBtn')).not.toBeInTheDocument()
+				expect(document.querySelector('.autoConnectBtn')).toBeInTheDocument()
 			})
 		})
 
@@ -212,7 +210,9 @@ describe('LoginModal component', () => {
 					queryByText('We found environment variables with connection details for')
 				).not.toBeInTheDocument()
 				expect(getByText('Almost there!')).toBeInTheDocument()
-				expect(getByText('Waiting for you to sign in...')).toBeInTheDocument()
+				expect(
+					getByText('Please go ahead and complete the login process in the opened browser')
+				).toBeInTheDocument()
 				expect(document.querySelector('.closeBtn')).toBeInTheDocument()
 				expect(document.querySelector('.text')).toBeInTheDocument()
 				expect(document.querySelector('.welcome')).toBeInTheDocument()

--- a/src/components/UI/Modal/pages/LoginModal.tsx
+++ b/src/components/UI/Modal/pages/LoginModal.tsx
@@ -124,8 +124,6 @@ function getAutoConnectBody(data: ILoginPage): JSX.Element {
 					<span>Would you like to use this configuration?</span>
 				</div>
 			)
-		case LoginConnectionType.Sso:
-			return <div>Waiting for you to sign in...</div>
 	}
 
 	return <> </>
@@ -133,7 +131,7 @@ function getAutoConnectBody(data: ILoginPage): JSX.Element {
 
 function getVerifyingBody(data: ILoginPage): JSX.Element {
 	if (data.connectionType === LoginConnectionType.Sso) {
-		return <div>Waiting for you to sign in...</div>
+		return <div>Please go ahead and complete the login process in the opened browser</div>
 	}
 
 	return <> </>

--- a/src/components/UI/Modal/pages/LoginModal.tsx
+++ b/src/components/UI/Modal/pages/LoginModal.tsx
@@ -70,36 +70,6 @@ function createSpinnerState(s: LoginProgressStatus): State {
 function createBody(data: ILoginPage): JSX.Element {
 	let pageBody = <> </>
 
-	switch (data.connectionType) {
-		case LoginConnectionType.Cli:
-			pageBody = (
-				<div className={css.autoLoginText}>
-					<span> It looks like JFrog CLI is installed with the connection details of</span>
-					<div>
-						<span className={css.textBold}>{data.url}</span>
-					</div>
-					<div />
-					<span>Would you like to use this configuration?</span>
-				</div>
-			)
-			break
-		case LoginConnectionType.EnvVars:
-			pageBody = (
-				<div className={css.autoLoginText}>
-					<span>Environment variables are set with the connection details of</span>
-					<div>
-						<span className={css.textBold}>{data.url}</span>
-					</div>
-					<div />
-					<span>Would you like to use this configuration?</span>
-				</div>
-			)
-			break
-		case LoginConnectionType.Sso:
-			pageBody = <div>Waiting for you to sign in...</div>
-			break
-	}
-
 	switch (data.status) {
 		case LoginProgressStatus.Failed:
 			pageBody = <div>Connection could not be established.</div>
@@ -119,39 +89,77 @@ function createBody(data: ILoginPage): JSX.Element {
 		case LoginProgressStatus.Success:
 			pageBody = <div>Your credentials will be securely stored on the machine for future use.</div>
 			break
+		case LoginProgressStatus.AutoConnect:
+			pageBody = getAutoConnectBody(data)
+			break
+		case LoginProgressStatus.Verifying:
+			pageBody = getVerifyingBody(data)
+			break
 	}
 
 	return <div className={css.text}>{pageBody}</div>
 }
 
+function getAutoConnectBody(data: ILoginPage): JSX.Element {
+	switch (data.connectionType) {
+		case LoginConnectionType.Cli:
+			return (
+				<div className={css.autoLoginText}>
+					<span> It looks like JFrog CLI is installed with the connection details of</span>
+					<div>
+						<span className={css.textBold}>{data.url}</span>
+					</div>
+					<div />
+					<span>Would you like to use this configuration?</span>
+				</div>
+			)
+		case LoginConnectionType.EnvVars:
+			return (
+				<div className={css.autoLoginText}>
+					<span>Environment variables are set with the connection details of</span>
+					<div>
+						<span className={css.textBold}>{data.url}</span>
+					</div>
+					<div />
+					<span>Would you like to use this configuration?</span>
+				</div>
+			)
+		case LoginConnectionType.Sso:
+			return <div>Waiting for you to sign in...</div>
+	}
+
+	return <> </>
+}
+
+function getVerifyingBody(data: ILoginPage): JSX.Element {
+	if (data.connectionType === LoginConnectionType.Sso) {
+		return <div>Waiting for you to sign in...</div>
+	}
+
+	return <> </>
+}
+
 function createTitle(data: ILoginPage): JSX.Element {
-	let title = <> </>
+	let title = ''
 
 	switch (data.status) {
 		case LoginProgressStatus.Failed:
 		case LoginProgressStatus.FailedBadCredentials:
 		case LoginProgressStatus.FailedTimeout:
 		case LoginProgressStatus.FailedServerNotFound:
-			title = <span>Sign in failed</span>
+			title = 'Sign in failed'
 			break
 		case LoginProgressStatus.Success:
-			title = <span>You&apos;re in!</span>
+			title = "You're in!"
 			break
 		case LoginProgressStatus.AutoConnect:
 			title =
-				data.connectionType === LoginConnectionType.Cli ? (
-					<span>Sign In Using JFrog CLI</span>
-				) : (
-					<span>Sign In Using Env-Var</span>
-				)
+				data.connectionType === LoginConnectionType.Cli
+					? 'Sign In Using JFrog CLI'
+					: 'Sign In Using Env-Var'
 			break
 		case LoginProgressStatus.Verifying:
-			title =
-				data.connectionType === LoginConnectionType.Sso ? (
-					<span>Almost there!</span>
-				) : (
-					<span>Verifying...</span>
-				)
+			title = data.connectionType === LoginConnectionType.Sso ? 'Almost there!' : 'Verifying...'
 	}
 
 	return <div className={css.welcome}>{title}</div>


### PR DESCRIPTION
On the verification login popup modal, remove the leftover text. 
Basically, the text `Environment variables are set with the connection details` would remain on the page after the user pressed 'Sure!'. This should be removed, while verifying the login.