### PR TITLE
Total impact paths counter was removed

### DIFF
--- a/src/components/Page/Dependency/Dependency.test.tsx
+++ b/src/components/Page/Dependency/Dependency.test.tsx
@@ -1,13 +1,13 @@
 import { queryByAttribute, render, screen } from '@testing-library/react'
 import Dependency from './Dependency'
 import {
-	IDependencyPage,
-	PageType,
-	ISeverity,
 	IApplicableDetails,
 	ICve,
+	IDependencyPage,
 	IEvidence,
-	IExtendedInformation
+	IExtendedInformation,
+	ISeverity,
+	PageType
 } from '../../../model'
 import { TABS } from '../../UI/InformationTabs/InformationTabs'
 
@@ -50,7 +50,6 @@ describe('Dependency page component', () => {
 			root: {
 				name: 'Impact Graph'
 			},
-			pathsCount: 1,
 			pathsLimit: 10
 		},
 		references: [{ url: 'url' }]

--- a/src/components/Page/Dependency/Navigator/page/ImpactGraph.tsx
+++ b/src/components/Page/Dependency/Navigator/page/ImpactGraph.tsx
@@ -3,7 +3,6 @@ import TreeContainer from '../../../../UI/TreeViewer/TreeContainer'
 
 export interface Props {
 	treeNode: TreeNode
-	pathsCount?: number
 	pathsLimit?: number
 }
 
@@ -11,7 +10,6 @@ export default function ImpactGraph(props: Props): JSX.Element {
 	return (
 		<TreeContainer
 			root={props.treeNode}
-			pathsCount={props.pathsCount}
 			pathsLimit={props.pathsLimit}
 		/>
 	)

--- a/src/components/UI/InformationTabs/InformationTabs.test.tsx
+++ b/src/components/UI/InformationTabs/InformationTabs.test.tsx
@@ -52,7 +52,6 @@ describe('InformationTabs component', () => {
 			root: {
 				name: 'Impact Graph'
 			},
-			pathsCount: 1,
 			pathsLimit: 10
 		},
 		references: [{ url: 'url' }]

--- a/src/components/UI/InformationTabs/InformationTabs.tsx
+++ b/src/components/UI/InformationTabs/InformationTabs.tsx
@@ -208,7 +208,6 @@ function InformationTabs(props: Props): JSX.Element {
 						<ImpactGraph
 							treeNode={treeNode}
 							pathsLimit={(props.data as IDependencyPage).impactGraph.pathsLimit}
-							pathsCount={(props.data as IDependencyPage).impactGraph.pathsCount}
 						/>
 					</CustomTabPanel>
 				)}

--- a/src/components/UI/InformationTabs/WhatCanIDoTab.test.tsx
+++ b/src/components/UI/InformationTabs/WhatCanIDoTab.test.tsx
@@ -53,7 +53,6 @@ describe('WhatCanIDoTab component', () => {
 			root: {
 				name: 'Impact Graph'
 			},
-			pathsCount: 1,
 			pathsLimit: 10
 		},
 		references: [{ url: 'url' }]
@@ -166,9 +165,7 @@ describe('WhatCanIDoTab component', () => {
 						]
 					}
 				]
-			},
-			pathsCount: 1,
-			pathsLimit: 50
+			}
 		}
 		render(
 			<WhatCanIDoTab

--- a/src/components/UI/TreeViewer/TreeContainer.test.tsx
+++ b/src/components/UI/TreeViewer/TreeContainer.test.tsx
@@ -74,7 +74,6 @@ describe('TreeContainer component', () => {
 		const root: TreeNode = new TreeNode('root', 'Root Node')
 		const props: Props = {
 			root: root,
-			pathsCount: 15,
 			pathsLimit: 10
 		}
 
@@ -82,7 +81,7 @@ describe('TreeContainer component', () => {
 
 		expect(
 			screen.getByText(
-				'Graph size limit reached. The Impact Graph shows only 10 out of 15 paths to this dependency.'
+				'Graph size limit reached. The Impact Graph shows only 10 paths to this dependency.'
 			)
 		).toBeInTheDocument()
 	})
@@ -91,15 +90,14 @@ describe('TreeContainer component', () => {
 		const root: TreeNode = new TreeNode('root', 'Root Node')
 		const props: Props = {
 			root: root,
-			pathsCount: 5,
-			pathsLimit: 10
+			pathsLimit: -1
 		}
 
 		render(<TreeContainer {...props} />)
 
 		expect(
 			screen.queryByText(
-				'Graph size limit reached. The Impact Graph shows only 10 out of 15 paths to this dependency.'
+				'Graph size limit reached. The Impact Graph shows only 10 paths to this dependency.'
 			)
 		).not.toBeInTheDocument()
 	})

--- a/src/components/UI/TreeViewer/TreeContainer.tsx
+++ b/src/components/UI/TreeViewer/TreeContainer.tsx
@@ -7,7 +7,6 @@ import Wrapper from '../Wrapper/Wrapper'
 
 export interface Props {
 	root: TreeNode
-	pathsCount?: number
 	pathsLimit?: number
 }
 
@@ -39,8 +38,8 @@ export default function TreeContainer(props: Props): JSX.Element {
 						<div className={css.noteWrapper}>
 							<span className={css.title}>Note: </span>
 							<span>
-								Graph size limit reached. The Impact Graph shows only {props.pathsLimit} out of{' '}
-								{props.pathsCount?.toLocaleString()} paths to this dependency.
+								Graph size limit reached. The Impact Graph shows only {props.pathsLimit} paths to
+								this dependency.
 							</span>
 						</div>
 					)}
@@ -62,5 +61,5 @@ export default function TreeContainer(props: Props): JSX.Element {
 }
 
 function graphSizeLimitReached(props: Props): boolean {
-	return (props.pathsCount && props.pathsLimit && props.pathsCount > props.pathsLimit) as boolean
+	return (props.pathsLimit && props.pathsLimit > 0) as boolean
 }

--- a/src/model/impactGraph.ts
+++ b/src/model/impactGraph.ts
@@ -1,6 +1,5 @@
 export interface IImpactGraph {
 	root: IImpactGraphNode
-	pathsCount?: number
 	pathsLimit?: number
 }
 

--- a/src/model/webviewPages.test.ts
+++ b/src/model/webviewPages.test.ts
@@ -60,9 +60,7 @@ describe('Model - WebviewPage', () => {
 							children: []
 						}
 					]
-				},
-				pathsCount: 2,
-				pathsLimit: 10
+				}
 			},
 			severity: ISeverity.High,
 			edited: '2022-01-01',

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -3,8 +3,8 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom'
-import { IDependencyPage, ISeverity, PageType } from './model'
-import { MatcherFunction } from '@testing-library/react'
+import {IDependencyPage, ISeverity, PageType} from './model'
+import {MatcherFunction} from '@testing-library/react'
 
 const fakeDependencyPage: IDependencyPage = {
 	id: 'XRAY-210300',
@@ -119,9 +119,7 @@ const fakeDependencyPage: IDependencyPage = {
 					]
 				}
 			]
-		},
-		pathsCount: 2,
-		pathsLimit: 10
+		}
 	}
 } as IDependencyPage
 


### PR DESCRIPTION
Updated the message displayed upon reaching the impact graph limit. It'll no longer show the number of paths that exist.

The `pathsCount` field has been removed and shouldn't be sent in messages to the webview anymore. The `pathsLimit` field will now be sent only when the limit is reached; otherwise, it should not be sent or filled with a negative number.