### PR TITLE
Init model  pop-up window on close

### DIFF
--- a/src/components/Page/Login/Login.tsx
+++ b/src/components/Page/Login/Login.tsx
@@ -20,6 +20,7 @@ export function Login(props: Props): JSX.Element {
 
 	const closeModal = (): void => {
 		setModal(false)
+		props.data.status = LoginProgressStatus.Initial
 	}
 
 	return (


### PR DESCRIPTION
This pull request addresses the problem where the modal pop-up window was displayed only for the initial interaction and failed to appear again subsequently.

For instance, initiating the Single Sign-On (SSO) modal view, exiting it, and attempting to reopen the SSO modal would not be successful.

To resolve this issue, we initialize the status upon closure, preventing it from remaining stuck in the last state and enabling proper functionality for subsequent interactions.