### PR TITLE
fix an issue that what can i do window shows that there is no remedia…

### DIFF
--- a/src/components/UI/InformationTabs/WhatCanIDoTab.tsx
+++ b/src/components/UI/InformationTabs/WhatCanIDoTab.tsx
@@ -131,7 +131,7 @@ export default function WhatCanIDoTab(props: Props): JSX.Element {
 	const hasFixedVersion = props.fixedVersion && props.fixedVersion.length > 0
 	const showSuppressFinding = [PageType.Sast, PageType.Secrets].includes(props.pageType)
 
-	const hasAction = hasFixedVersion ?? props.remediation ?? showSuppressFinding
+	const hasAction = props.remediation ?? hasFixedVersion ?? showSuppressFinding
 	return (
 		<div className={css.container}>
 			{!hasAction && <EmptyStateContainer />}


### PR DESCRIPTION
Fix an issue when there was a remediation but it still returned a window that there is no remediation. 
The issue happens when hasFixedVersion is an empty string so it doesn't check remediation but hasAction is still false.
Changed the priority checking for hasAction.